### PR TITLE
fix : 無限スクロールが機能しない現象を修正

### DIFF
--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -14,7 +14,6 @@
 <script src="{% static 'blog/js/jquery.waypoints.min.js' %}"></script>
 <script src="{% static 'blog/js/infinite.min.js' %}"></script>
 
-{% block extrajs %}{% endblock %}
 </head>
     <body>
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark" style="position:sticky; top:0;">
@@ -28,5 +27,6 @@
 {% endblock %}
 </div>
 
+    {% block extrajs %}{% endblock %}
     </body>
 </html>


### PR DESCRIPTION
extrajsブロックを読み込む位置がinfinite-containerクラスを含むdiv要素よりも前側にあったために、new Waypoint.Infinite()が呼ばれた時点でまだinfinite-containerクラスが存在していなかったためにうまく動作しておりませんでした。

対処としましては、extrajsブロックをbody終了タグの手前に移動することにより、上記現象を回避いたしました。